### PR TITLE
Remove failing assert

### DIFF
--- a/src/setuptools_dso/dsocmd.py
+++ b/src/setuptools_dso/dsocmd.py
@@ -722,7 +722,6 @@ class bdist_egg(_bdist_egg):
 # if right_before is specified build_dso is injected before that command
 # instead of as first dependency.
 def _needs_builddso(command, right_before=None):
-    assert issubclass(command, Command)
     # copy to avoid changing base class if sub_commands was just inherited
     _ = command.sub_commands[:]
     where = 0


### PR DESCRIPTION
As of setuptools 77.0.3, this assert is no longer passing. This means projects that require this for building cannot build, and projects that use it at runtime (e.g. cothread's catools) cannot run.

It should be noted that this passes under setuptools 77.0.1, so there is apparently a breaking change in a minor release.

I'm creating this PR as this is a major blocker for the Bluesky projects, in the hopes we can quickly make a minor patch release. I'm still investigating the underlying cause of this new failure and may have more to say in the future.